### PR TITLE
[config] Add 'config interface mtu' command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1401,6 +1401,27 @@ def mgmt_ip_restart_services():
     os.system (cmd)
 
 #
+# 'mtu' subcommand
+#
+
+@interface.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_mtu', metavar='<interface_mtu>', required=True)
+@click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
+def mtu(ctx, interface_name, interface_mtu, verbose):
+    """Set interface speed"""
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    command = "portconfig -p {} -m {}".format(interface_name, interface_mtu)
+    if verbose:
+        command += " -vv"
+    run_command(command, display_cmd=verbose)
+
+#
 # 'ip' subgroup ('config interface ip ...')
 #
 

--- a/config/main.py
+++ b/config/main.py
@@ -1410,7 +1410,7 @@ def mgmt_ip_restart_services():
 @click.argument('interface_mtu', metavar='<interface_mtu>', required=True)
 @click.option('-v', '--verbose', is_flag=True, help="Enable verbose output")
 def mtu(ctx, interface_name, interface_mtu, verbose):
-    """Set interface speed"""
+    """Set interface mtu"""
     if get_interface_naming_mode() == "alias":
         interface_name = interface_alias_to_name(interface_name)
         if interface_name is None:

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2417,6 +2417,22 @@ Dynamic breakout feature is yet to be supported in SONiC and hence uses cannot c
   admin@sonic:~$ sudo config interface Ethernet63 speed 40000
   ```
 
+**config interface mtu <interface_name> (Versions >= 201904)**
+
+This command is used to configure the mtu for the Physical interface. Use the value 1500 for setting max transfer unit size to 1500 bytes.
+
+- Usage:
+
+  *Versions >= 201904*
+  ```
+  config interface mtu <interface_name> <mtu_value>
+  ```
+
+- Example (Versions >= 201904):
+  ```
+  admin@sonic:~$ sudo config interface mtu Ethernet64 1500
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#interfaces)
 
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -2,7 +2,7 @@
 """
 portconfig is the utility to show and change ECN configuration
 
-usage: portconfig [-h] [-v] [-s] [-f] [-p PROFILE] [-gmin GREEN_MIN]
+usage: portconfig [-h] [-v] [-s] [-f] [-m] [-p PROFILE] [-gmin GREEN_MIN]
                  [-gmax GREEN_MAX] [-ymin YELLOW_MIN] [-ymax YELLOW_MAX]
                  [-rmin RED_MIN] [-rmax RED_MAX] [-vv]
 
@@ -13,6 +13,7 @@ optional arguments:
   -p     --port                port name
   -s     --speed               port speed in Mbits
   -f     --fec                 port fec mode
+  -m     --mtu                 port mtu in bytes
 """
 from __future__ import print_function
 

--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -25,6 +25,7 @@ import swsssdk
 PORT_TABLE_NAME = "PORT"
 PORT_SPEED_CONFIG_FIELD_NAME = "speed"
 PORT_FEC_CONFIG_FIELD_NAME = "fec"
+PORT_MTU_CONFIG_FIELD_NAME = "mtu"
 
 class portconfig(object):
     """
@@ -57,6 +58,11 @@ class portconfig(object):
             print("Setting fec %s on port %s" % (fec, port))
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_FEC_CONFIG_FIELD_NAME: fec})
 
+    def set_mtu(self, port, mtu):
+        if self.verbose:
+            print("Setting mtu %s on port %s" % (mtu, port))
+        self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_MTU_CONFIG_FIELD_NAME: mtu})
+
 def main():
     parser = argparse.ArgumentParser(description='Set SONiC port parameters',
                          version='1.0.0',
@@ -65,6 +71,7 @@ def main():
     parser.add_argument('-l', '--list', action='store_true', help='list port parametars', default=False)
     parser.add_argument('-s', '--speed', type=int, help='port speed value in Mbit', default=None)
     parser.add_argument('-f', '--fec', type=str, help='port fec mode value in (none, rs, fc)', default=None)
+    parser.add_argument('-m', '--mtu', type=int, help='port mtu value in bytes', default=None)
     parser.add_argument('-vv', '--verbose', action='store_true', help='Verbose output', default=False)
     args = parser.parse_args()
 
@@ -72,11 +79,13 @@ def main():
         port = portconfig(args.verbose, args.port)
         if args.list:
             port.list_params(args.port)
-        elif args.speed or args.fec:
+        elif args.speed or args.fec or args.mtu:
             if args.speed:
                 port.set_speed(args.port, args.speed)
             if args.fec:
                 port.set_fec(args.port, args.fec)
+            if args.mtu:
+                port.set_mtu(args.port, args.mtu)
         else:
             parser.print_help()
             sys.exit(1)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Implemented config interface mtu subcommand.

**- How I did it**
1. Implemented mtu() method in config/main.py for parsing MTU parameter.
2. Updated scripts/portconfig to enable correct hadling of MTU value.

**- How to verify it**
1. Use config interface mtu command to set MTU on any Ethernet interface.
2. Use show interfaces status to whether the MTU value of the port has changed in the database.
3. Use ifconfig to check if the MTU change has been correcly handled by a subscriber.

**- Usage example**

`admin@sonic:~$ sudo config interface mtu Ethernet64 1500`


